### PR TITLE
feat: bump results to 50

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,7 @@ const config = {
   autocompleteQuery: buildAutocompleteQueryConfig(),
   apiConnector: connector,
   alwaysSearchOnInitialLoad: false,
+  initialState: { resultsPerPage: 50 },
 };
 
 const CustomPagingInfoView = ({ totalResults }) => {


### PR DESCRIPTION
closes #29 

Performance for rendering 20 to 50 results would be negligible. 
Network performance for 20 results ~ 1.024 seconds
Network performance for 50 results ~ 1.438 seconds
*results are an average of 5 network tests